### PR TITLE
ターゲットフレームワークを .NET 8.0 に更新

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "AupDotNet"]
-	path = AupDotNet
-	url = https://github.com/karoterra/AupDotNet.git

--- a/aup2exedit_backup.sln
+++ b/aup2exedit_backup.sln
@@ -5,8 +5,6 @@ VisualStudioVersion = 17.0.32014.148
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "aup2exedit_backup", "aup2exedit_backup\aup2exedit_backup.csproj", "{DDD99506-14CD-4159-9EC9-35DCE4C3F4C9}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AupDotNet", "AupDotNet\src\AupDotNet\AupDotNet.csproj", "{EAF59BC3-E4F5-478B-B873-FDAF0881F12A}"
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -17,10 +15,6 @@ Global
 		{DDD99506-14CD-4159-9EC9-35DCE4C3F4C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DDD99506-14CD-4159-9EC9-35DCE4C3F4C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DDD99506-14CD-4159-9EC9-35DCE4C3F4C9}.Release|Any CPU.Build.0 = Release|Any CPU
-		{EAF59BC3-E4F5-478B-B873-FDAF0881F12A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{EAF59BC3-E4F5-478B-B873-FDAF0881F12A}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EAF59BC3-E4F5-478B-B873-FDAF0881F12A}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{EAF59BC3-E4F5-478B-B873-FDAF0881F12A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/aup2exedit_backup/ExeditBackup.cs
+++ b/aup2exedit_backup/ExeditBackup.cs
@@ -27,7 +27,7 @@ namespace aup2exedit_backup
             var span = new ReadOnlySpan<byte>(data);
             FormatVersion = span.ToUInt32();
             ExeditVersion = span[0x2C..].ToUInt32();
-            FrameNum = editHandle.FrameNum;
+            FrameNum = editHandle.Frames.Count;
             Width = editHandle.Width;
             Height = editHandle.Height;
             VideoRate = editHandle.VideoRate;

--- a/aup2exedit_backup/aup2exedit_backup.csproj
+++ b/aup2exedit_backup/aup2exedit_backup.csproj
@@ -11,11 +11,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommandLineParser" Version="2.8.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <ProjectReference Include="..\AupDotNet\src\AupDotNet\AupDotNet.csproj" />
+    <PackageReference Include="CommandLineParser" Version="2.9.1" />
+    <PackageReference Include="Karoterra.AupDotNet" Version="0.2.0" />
   </ItemGroup>
 
 </Project>

--- a/aup2exedit_backup/aup2exedit_backup.csproj
+++ b/aup2exedit_backup/aup2exedit_backup.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Version>0.1.0</Version>


### PR DESCRIPTION
.NET 6 のサポート期間が終了したので、LTSである .NET 8 にターゲットフレームワークを更新した。
依存パッケージを更新した。
AupDotNet をサブモジュールとしておく必要がなくなったためサブモジュールを削除した。